### PR TITLE
fix: Add testnet true in dukong

### DIFF
--- a/cosmos/mantra-dukong.json
+++ b/cosmos/mantra-dukong.json
@@ -52,5 +52,6 @@
     "eth-address-gen",
     "eth-key-sign",
     "eth-secp256k1-cosmos"
-  ]
+  ],
+  "isTestnet": true
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mantra Dukong is now identified as a Testnet across the app. Users will see updated labels, badges, and filters reflecting its testnet status wherever network type is displayed or selectable.
* **Chores**
  * Updated network metadata to include a testnet flag for Mantra Dukong, ensuring consistent classification and behavior in UI components that depend on network type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->